### PR TITLE
#21 defining Ansible 2.3.x.x as minimum version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tests/__pycache__
 .molecule
 .vagrant
 .cache
+.python-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/java-role/tree/develop)
 
+### Fixed
+- *[#21](https://github.com/idealista/java-role/issues/21) Defined Ansible 2.3.x.x as min version* @dortegau
+
 ## [2.0.1](https://github.com/idealista/java-role/tree/2.0.1)
 ### Fixed
 - *[#18](https://github.com/idealista/java-role/issues/18) OracleJDK 8 URL is not working* @jnogol

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ These instructions will get you a copy of the role for your ansible playbook. On
 
 ### Prerequisities
 
-Ansible 2.2.1.0 version installed.
+Ansible 2.3.1.0 version installed.
 Inventory destination should be a Debian environment.
 
 For testing purposes, [Molecule](https://molecule.readthedocs.io/) with [Vagrant](https://www.vagrantup.com/) as driver and [VirtualBox](https://www.virtualbox.org/) as provider.
@@ -85,7 +85,7 @@ See molecule.yml to check possible testing platforms.
 
 ## Built With
 
-![Ansible](https://img.shields.io/badge/ansible-2.2.1.0-green.svg)
+![Ansible](https://img.shields.io/badge/ansible-2.3.1.0-green.svg)
 
 ## Versioning
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   company: Idealista S.A.U.
   description: Java role, install java versions and set systems default
-  min_ansible_version: 2.2.1.0
+  min_ansible_version: 2.3.1.0
   license: Apache 2.0
   platforms:
     - name: Debian


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Defined Ansible 2.3.1.0 as minimum version

### Applicable Issues

#21 
