### PR TITLE
Use updated syntax for installing packages through apt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/java-role/tree/develop)
+### Changed
+- #36 *Use new apt syntax for installing packages* @sklirg
 
 ## [3.0.2](https://github.com/idealista/java-role/tree/3.0.2) (2018-10-18)
 [Full Changelog](https://github.com/idealista/java-role/compare/3.0.1...3.0.2)

--- a/tasks/install_openjdk.yml
+++ b/tasks/install_openjdk.yml
@@ -15,36 +15,32 @@
 
 - name: Java | Installing dependencies
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ java_required_libs_openjdk }}"
     update_cache: yes
     state: present
     default_release: "{{ debian_release }}"
-  with_items: "{{ java_required_libs_openjdk }}"
   when: ansible_distribution in [ 'Debian' ]
 
 - name: Java | Installing dependencies
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ java_required_libs_openjdk }}"
     update_cache: yes
     state: present
-  with_items: "{{ java_required_libs_openjdk }}"
   when: ansible_distribution in [ 'Ubuntu' ]
 
 - name: Java | Install Java
   apt:
-    name: "openjdk-{{ item }}-jdk"
+    name: "openjdk-{{ java_open_jdk_version }}-jdk"
     state: present
     update_cache: yes
     default_release: "{{ debian_release }}"
-  with_items: "{{ java_open_jdk_version }}"
   when: ansible_distribution in [ 'Debian' ]
 
 - name: Java | Install Java
   apt:
-    name: "openjdk-{{ item }}-jdk"
+    name: "openjdk-{{ java_open_jdk_version }}-jdk"
     state: present
     update_cache: yes
-  with_items: "{{ java_open_jdk_version }}"
   when: ansible_distribution in [ 'Ubuntu' ]
 
 - name: Java | Update Env


### PR DESCRIPTION
### Requirements

* [x] Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* [ ] All new code requires tests to ensure against regressions (_not changing any code; just updating existing_)
* [x] Remember to set **idealista:develop** as base branch;

### Description of the Change

Updates the role to use current (/new) syntax for apt packages. Removes an ansible loop and pushes the package list straight through to apt.

Removes the following deprecation warning:
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and
specifying `pkg: {{ item }}`, please use `pkg: '{{ java_required_libs_openjdk }}'` and remove the loop. This feature will be removed in version 2.11.
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

### Benefits

This removes a deprecation warning, which states the current way to do things will be removed in ansible 2.11.

### Possible Drawbacks

Maybe this isn't backported? I'm not sure.

### Applicable Issues

N/A
