### PR TITLE
Version 1.8.0_201 is available, downloadable and the new default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/java-role/tree/develop)
+### Changed
+- *[#70](https://github.com/idealista/java-role/issues/70) New available Oracle Java versions added. Default Oracle JDK is now 1.8.0_201* @mmolinac
 ### Added
 - *[#65](https://github.com/idealista/java-role/issues/65) Add Travis deployment for Ubuntu 18.04 Bionic* @jnogol
 ### Changed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ java_implementation: openjdk
 # OracleJDK implementation (provides only support for x64 architectures)
 # [1.8.0_191, 1.8.0_192, 11.0.1] (see available urls in ../vars/main.yml)
 java_oracle_jdk_version_major: 8
-java_oracle_jdk_version: 1.8.0_191
+java_oracle_jdk_version: 1.8.0_201
 java_oracle_jdk_install_path: /opt/jdk/{{ java_oracle_jdk_version }}
 
 # OpenJDK implementation

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,10 @@
 # Older versions requires login to be downloaded
 # http://www.oracle.com/technetwork/java/archive-139210.html
 java_oracle_jdk_latest_versions_urls:
+  1.8.0_201:
+    url: https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz
+    # https://www.oracle.com/webfolder/s/digest/8u201checksum.html
+    sha256: cb700cc0ac3ddc728a567c350881ce7e25118eaf7ca97ca9705d4580c506e370
   1.8.0_191:
     url: http://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/jdk-8u191-linux-x64.tar.gz
     # http://www.oracle.com/webfolder/s/digest/8u191checksum.html

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,10 @@
 # Older versions requires login to be downloaded
 # http://www.oracle.com/technetwork/java/archive-139210.html
 java_oracle_jdk_latest_versions_urls:
+  1.8.0_202:
+    url: https://download.oracle.com/otn-pub/java/jdk/8u202-b08/1961070e4c9b4e26a04e7f5a083f551e/jdk-8u202-linux-x64.tar.gz
+    # https://www.oracle.com/webfolder/s/digest/8u202checksum.html
+    sha256: 9a5c32411a6a06e22b69c495b7975034409fa1652d03aeb8eb5b6f59fd4594e0
   1.8.0_201:
     url: https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz
     # https://www.oracle.com/webfolder/s/digest/8u201checksum.html

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,14 +11,6 @@ java_oracle_jdk_latest_versions_urls:
     url: https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz
     # https://www.oracle.com/webfolder/s/digest/8u201checksum.html
     sha256: cb700cc0ac3ddc728a567c350881ce7e25118eaf7ca97ca9705d4580c506e370
-  1.8.0_191:
-    url: http://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/jdk-8u191-linux-x64.tar.gz
-    # http://www.oracle.com/webfolder/s/digest/8u191checksum.html
-    sha256: 53c29507e2405a7ffdbba627e6d64856089b094867479edc5ede4105c1da0d65
-  1.8.0_192:
-    url: http://download.oracle.com/otn-pub/java/jdk/8u192-b12/750e1c8617c5452694857ad95c3ee230/jdk-8u192-linux-x64.tar.gz
-    # http://www.oracle.com/webfolder/s/digest/8u192checksum.html
-    sha256: 6d34ae147fc5564c07b913b467de1411c795e290356538f22502f28b76a323c2
   11.0.1:
     url: http://download.oracle.com/otn-pub/java/jdk/11.0.1+13/90cf5d8f270a4347a95050320eef3fb7/jdk-11.0.1_linux-x64_bin.tar.gz
     # http://www.oracle.com/webfolder/s/digest/11-0-1checksum.html

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,7 +11,7 @@ java_oracle_jdk_latest_versions_urls:
     url: https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz
     # https://www.oracle.com/webfolder/s/digest/8u201checksum.html
     sha256: cb700cc0ac3ddc728a567c350881ce7e25118eaf7ca97ca9705d4580c506e370
-  11.0.1:
-    url: http://download.oracle.com/otn-pub/java/jdk/11.0.1+13/90cf5d8f270a4347a95050320eef3fb7/jdk-11.0.1_linux-x64_bin.tar.gz
-    # http://www.oracle.com/webfolder/s/digest/11-0-1checksum.html
-    sha256: e7fd856bacad04b6dbf3606094b6a81fa9930d6dbb044bbd787be7ea93abc885
+  11.0.2:
+    url: https://download.oracle.com/otn-pub/java/jdk/11.0.2+7/f51449fcd52f4d52b93a989c5c56ed3c/jdk-11.0.2_linux-x64_bin.tar.gz
+    # https://www.oracle.com/webfolder/s/digest/11-0-2checksum.html
+    sha256: 1f14572cae12adec64d28fdbf38935df7ced20b3efb54c33934b8bbecafdcd79


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Since one/some days, the default versions of Oracle JDK this role installed aren't available anymore on the respective web locations.

Thus, the role is not working as expected.

### Benefits

To solve the problem in the short term, I've realized there are two new versions and I took the location of one of them and added it to the current structure.

For the time being, the role with its default values just works.

### Possible Drawbacks

If you wanted the old versions, you're done, because this PR doesn't solve that.
I've been unable to reach the older versions (yet).

### Applicable Issues

Solves https://github.com/idealista/java-role/issues/70
